### PR TITLE
Minor fix to the error handler for getFeed.

### DIFF
--- a/lib/spreadsheets.js
+++ b/lib/spreadsheets.js
@@ -34,6 +34,14 @@ var getFeed = function(params, auth, query, cb) {
 		url: url,
 		headers: headers
 	}, function(err, response, body) {
+        if(err) {
+            cb(err);
+            return;
+        }
+        if(!response) {
+            cb(new Error("Missing response."));
+            return;
+        }
 		if(response.statusCode === 401) {
 			cb(new Error("Invalid authorization key."));
 		}


### PR DESCRIPTION
One version of node had some cert problem with talking to google servers
and the error message about it was useless. Passing though the error
message from the request was helpful to figuring that out (and probably
the right thing to do).
