### PR TITLE
Try changing Authorization header to be 'Bearer' instead of 'GoogleLogin

### DIFF
--- a/lib/spreadsheets.js
+++ b/lib/spreadsheets.js
@@ -22,7 +22,8 @@ var getFeed = function(params, auth, query, cb) {
   var projection = "values";
 
   if(auth) {
-    headers.Authorization = "GoogleLogin auth=" + auth;
+    // headers.Authorization = "GoogleLogin auth=" + auth;
+    headers.Authorization = "Bearer " + auth;
     visibility = "private";
     projection = "full";
   }


### PR DESCRIPTION
With OAuth2 tokens, the Authorization header needs to be "Bearer <token>".

The OAuth1 tokens will be deprecated as of May 5, 2015, and they currently do not work with new style Google Spreadsheets. This change will break existing code that uses OAuth1 tokens though. Perhaps another option needs to be added?