### PR TITLE
Fix unhandled exception on existing but unpublished spreadsheets.

### DIFF
--- a/lib/spreadsheets.js
+++ b/lib/spreadsheets.js
@@ -189,7 +189,14 @@ Spreadsheets = module.exports = function(opts, cb) {
       return cb(err);
     }
 
-    cb(null, new Spreadsheet(opts.key, opts.auth, data));
+    var spreadSheet = null;
+    try {
+        spreadSheet = new Spreadsheet(opts.key, opts.auth, data);
+    } catch (ex) {
+        cb(ex, null);
+        return;
+    }
+    cb(null, spreadSheet);
   });
 };
 

--- a/test/test.js
+++ b/test/test.js
@@ -66,4 +66,12 @@ describe("google-spreadsheets", function() {
 			done();
 		});
 	});
+	it("fails gracefully on unpublished spreadsheets", function(done) {
+		GoogleSpreadsheets({
+			key: "1Y9_ldGHQt6SWXsu18BlAWQKYu_axFfowlqhJ97SxEHQ"
+		}, function(err) {
+			err.message.should.equal("Cannot read property \'title\' of undefined");
+			done();
+		});
+	});
 });


### PR DESCRIPTION
When I try to access a spreadsheet that has a valid key but is not yet published to the web the module runs on exception which can't be handled by the application using the module. With this PR the exception is caught and passed back to the application through the provided callback.