### PR TITLE
Browserified

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 coverage/
+lib/spreadsheets.browser.*

--- a/README.md
+++ b/README.md
@@ -40,6 +40,21 @@ GoogleSpreadsheets({
 });
 ```
 
+### In browser
+
+Build browser bundle with `npm run build`. Then include
+`lib/spreadsheets.browser.min.js` in your HTML:
+
+```html
+<script src="http://url.to/spreadsheets.browser.min.js"></script>
+```
+
+Usage is same as above, module is available at `window.Spreadsheets`:
+
+```js
+window.Spreadsheets(options, callback);
+```
+
 ## Authentication
 
 By default, `google-spreadsheets` will attempt requests for a spreadsheet as an unauthenticated (anonymous) user. There are some caveats to this, which you should read about in the [Anonymous Requests](#Anonymous Requests) section below.

--- a/package.json
+++ b/package.json
@@ -18,11 +18,14 @@
     "semver": "^4.3.6"
   },
   "devDependencies": {
+    "browserify": "*",
     "istanbul": "~0.3.2",
     "mocha": "^2.1.0",
-    "should": "^5.0.1"
+    "should": "^5.0.1",
+    "uglifyjs": "*"
   },
   "scripts": {
+    "build": "browserify --standalone Spreadsheets lib/spreadsheets.js -o lib/spreadsheets.browser.js && uglifyjs lib/spreadsheets.browser.js -o lib/spreadsheets.browser.min.js",
     "test": "[ -n \"$NO_COVERAGE\" ] && mocha || istanbul cover _mocha"
   },
   "jshintConfig": {


### PR DESCRIPTION
Hi, nice module!
I was happy to find out google-spreadsheets works nice in browsers when bundled with browserify. [Here](http://embed.plnkr.co/NYaldI/preview) is an example usage, a client-only "flashcards" app that I use in my classroom (students fill in questions in the spreadsheet, then they play the game).

A client bundle might be useful for others too, so I made this small PR. Also, you might consider publishing the bundled files to a `gh-pages`-branch, so they can be served directly of github (raw.github.com gives type text, not script).

:octocat: :smile: