### PR TITLE
add browser test with phantomjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,11 +22,13 @@
     "googleapis": "^2.1.6",
     "istanbul": "^0.4.0",
     "mocha": "^2.3.3",
+    "mochify": "^2.14.2",
     "should": "^7.1.1",
     "uglifyjs": "*"
   },
   "scripts": {
     "build": "browserify --standalone Spreadsheets lib/spreadsheets.js -o lib/spreadsheets.browser.js && uglifyjs lib/spreadsheets.browser.js -o lib/spreadsheets.browser.min.js",
+    "browser-test": "mochify --ignore-ssl-errors",
     "test": "istanbul test _mocha"
   },
   "jshintConfig": {

--- a/test/test.js
+++ b/test/test.js
@@ -2,7 +2,12 @@
 
 var assert = require("assert");
 var GoogleSpreadsheets = require("../lib/spreadsheets");
-var google = require("googleapis");
+try {
+  // browserify fails requiring googleapis
+  var google = require("googleapis");
+} catch(e) {
+  console.log("Not testing Google API.")
+}
 require("should");
 
 describe("google-spreadsheets", function() {


### PR DESCRIPTION
- run with `npm run browser-test`
- browserify fails in requiring `googleapis`; try, catch the import error
- "fails gracefully on unpublished spreadsheets" fails with an uncaught
  Type error.