### PR TITLE
lighter browser build

### DIFF
--- a/lib/spreadsheets.js
+++ b/lib/spreadsheets.js
@@ -1,7 +1,7 @@
 "use strict";
 
 var request = require("request");
-var http = require("http");
+var statuses = require("statuses");
 var querystring = require("querystring");
 
 // If caller has installed googleapis, we do some sanity checking to make sure it's a version we know.
@@ -72,7 +72,7 @@ var getFeed = function(params, auth, query, cb) {
     }
 
     if (response.statusCode >= 400) {
-      return cb(new Error("HTTP error " + response.statusCode + ": " + http.STATUS_CODES[response.statusCode]));
+      return cb(new Error("HTTP error " + response.statusCode + ": " + statuses[response.statusCode]));
     }
 
     cb(null, body.feed);

--- a/package.json
+++ b/package.json
@@ -13,11 +13,16 @@
   "engines": {
     "node": ">= 0.10.0"
   },
+  "browser": {
+    "request": "browser-request"
+  },
   "dependencies": {
     "request": "^2.65.0",
-    "semver": "^5.0.3"
+    "semver": "^5.0.3",
+    "statuses": "^1.2.1"
   },
   "devDependencies": {
+    "browser-request": "^0.3.3",
     "browserify": "^12.0.1",
     "googleapis": "^2.1.6",
     "istanbul": "^0.4.0",


### PR DESCRIPTION
- 1.5M -> 64k before uglify, 39k uglified
- use `browser-request` instead of `request`
- use `statuses` instead of node `http`
- fixes #37