### PR TITLE
add support for Google Team Drive

### DIFF
--- a/lib/spreadsheets.js
+++ b/lib/spreadsheets.js
@@ -120,10 +120,17 @@ var Spreadsheet = function(key, auth, data) {
   this.auth = auth;
   this.title = data.title.$t;
   this.updated = data.updated.$t;
-  this.author = {
-    name: data.author[0].name.$t,
-    email: data.author[0].email.$t
-  };
+  if (typeof data.author[0].name == "undefined" || typeof data.author[0].email == "undefined") {
+    this.author = {
+      name: "Team Drive",
+      email: "teamdrive@gmail.com"
+    }
+  } else {
+    this.author = {
+      name: data.author[0].name.$t,
+      email: data.author[0].email.$t
+    }
+  }
 
   this.worksheets = [];
   var worksheets = forceArray(data.entry);

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
-  "author": "Sam <me@samcday.com.au> (http://samcday.com.au/)",
-  "name": "google-spreadsheets",
-  "description": "Google Spreadsheet Data API for Node.js",
+  "author": "Machiko Yasuda",
+  "name": "google-team-drive-spreadsheets",
+  "description": "Google Spreadsheet Data API for Node.js, with Team Drive support - Forked from Node Google Spreadsheets",
   "version": "0.5.1",
   "license": "Unlicense",
-  "homepage": "https://github.com/samcday/node-google-spreadsheets",
+  "homepage": "https://github.com/machikoyasuda/node-google-spreadsheets",
   "repository": {
     "type": "git",
-    "url": "git://github.com/samcday/node-google-spreadsheets.git"
+    "url": "git://github.com/machikoyasuda/node-google-spreadsheets.git"
   },
   "main": "lib/spreadsheets.js",
   "engines": {

--- a/test/test.js
+++ b/test/test.js
@@ -23,6 +23,17 @@ describe("google-spreadsheets", function() {
 			done();
 		});
 	});
+  it("can load a Team Drive spreadsheet", function(done) {
+    GoogleSpreadsheets({
+      key: "1sla_yK0U3bVzTEby-rt5_hLFDDxlDfhn59JRRZe_QjA"
+    }, function(err, spreadsheet) {
+      if(err) return done(err);
+      spreadsheet.title.should.equal("Example Team Drive sheet");
+      spreadsheet.author.name.should.equal("Team Drive");
+      spreadsheet.author.email.should.equal("teamdrive@gmail.com");
+      done();
+    });
+  });
 	it("can load spreadsheet cells", function(done) {
 		GoogleSpreadsheets({
 			key: "0ApDvWFF4RPZBdEFucnJya1hxVG9wZzhJQWZUWkpfekE"


### PR DESCRIPTION
- Adds support Google Team Drive spreadsheets, which were failing, because Google Team Drive sheets do not have an Author object.
- Adds undefined check for Author
- Adds spec

Closes https://github.com/samcday/node-google-spreadsheets/issues/43